### PR TITLE
Fix test

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -34,7 +34,7 @@ describe('Instances of Person', () => {
     it('can eat no more than 10 foods', () => {
       foods.forEach(item => neo.eat(item))
       neo.eat(11)
-      expect(neo.stomach).not.toBe(11)
+      expect(neo.stomach).not.toContain(11)
     })
     it('can poop to empty stomach', () => {
       foods.forEach(item => neo.eat(item))


### PR DESCRIPTION
Fix jest matcher to catch the current false positive inside `can eat no more than 10 foods` case

cc: @BrityHemming
(tagging you as I see this repo has had almost no activity recently and at the time of creating this, you were the last person to make a commit)